### PR TITLE
Remove @xrplkit/txmeta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "@xrplkit/txmeta": "^1.2.0",
         "buffer": "^6.0.3",
         "nft.storage": "^7.0.3",
         "react": "^18.2.0",
@@ -5327,33 +5326,6 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
-    },
-    "node_modules/@xrplkit/amount": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@xrplkit/amount/-/amount-1.2.1.tgz",
-      "integrity": "sha512-alB5IfvoC9eRaFpI4GcdgalTv/ysvu2fNb6v5iG6SzGU7wniKS4K9TKJmiijBF8sISmE8AEcVg+4XCgMpCfD2g==",
-      "dependencies": {
-        "@xrplkit/xfl": "2.0.1"
-      }
-    },
-    "node_modules/@xrplkit/amount/node_modules/@xrplkit/xfl": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@xrplkit/xfl/-/xfl-2.0.1.tgz",
-      "integrity": "sha512-3v3iUw44HD4vV9aRpu6etvcggOPSYnapJ7c08JSk3RUeg2u/VyPW4WBqmylERjr5QkLH5qjPHDKd/Q5gLCuNpg=="
-    },
-    "node_modules/@xrplkit/txmeta": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xrplkit/txmeta/-/txmeta-1.2.0.tgz",
-      "integrity": "sha512-7rpRRiyShnepQverZnWkPQEXlLm2vfww+lp5KmMe3GyEMe6tRXQH8vIcQtWri6Vr9cHfNXE3k+/86gxpHCi9zw==",
-      "dependencies": {
-        "@xrplkit/amount": "1.2.1",
-        "@xrplkit/xfl": "2.0.2"
-      }
-    },
-    "node_modules/@xrplkit/xfl": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@xrplkit/xfl/-/xfl-2.0.2.tgz",
-      "integrity": "sha512-OUZZzSoXSxYxuhBcz08Wb9Xme71PkFYejk3vq4jPzdXreVhF71ZrM6nSObHFgasC8/srWKoqiS37CnB2Ht3k/g=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -24176,35 +24148,6 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
-    },
-    "@xrplkit/amount": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@xrplkit/amount/-/amount-1.2.1.tgz",
-      "integrity": "sha512-alB5IfvoC9eRaFpI4GcdgalTv/ysvu2fNb6v5iG6SzGU7wniKS4K9TKJmiijBF8sISmE8AEcVg+4XCgMpCfD2g==",
-      "requires": {
-        "@xrplkit/xfl": "2.0.1"
-      },
-      "dependencies": {
-        "@xrplkit/xfl": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@xrplkit/xfl/-/xfl-2.0.1.tgz",
-          "integrity": "sha512-3v3iUw44HD4vV9aRpu6etvcggOPSYnapJ7c08JSk3RUeg2u/VyPW4WBqmylERjr5QkLH5qjPHDKd/Q5gLCuNpg=="
-        }
-      }
-    },
-    "@xrplkit/txmeta": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xrplkit/txmeta/-/txmeta-1.2.0.tgz",
-      "integrity": "sha512-7rpRRiyShnepQverZnWkPQEXlLm2vfww+lp5KmMe3GyEMe6tRXQH8vIcQtWri6Vr9cHfNXE3k+/86gxpHCi9zw==",
-      "requires": {
-        "@xrplkit/amount": "1.2.1",
-        "@xrplkit/xfl": "2.0.2"
-      }
-    },
-    "@xrplkit/xfl": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@xrplkit/xfl/-/xfl-2.0.2.tgz",
-      "integrity": "sha512-OUZZzSoXSxYxuhBcz08Wb9Xme71PkFYejk3vq4jPzdXreVhF71ZrM6nSObHFgasC8/srWKoqiS37CnB2Ht3k/g=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@xrplkit/txmeta": "^1.2.0",
     "buffer": "^6.0.3",
     "nft.storage": "^7.0.3",
     "react": "^18.2.0",

--- a/src/__test__/__mock__/XrplClient.js
+++ b/src/__test__/__mock__/XrplClient.js
@@ -536,6 +536,8 @@ export class XrplClient {
         ],
         TransactionIndex: 8,
         TransactionResult: 'tesSUCCESS',
+        nftoken_id:
+          '000A1EA4511569DD226DFBE9472AC240000FCA5F212289F4DE07D4DC0000008E',
       },
       hash: '9DFB911F8916695710042EEB7BF6D83A987AA5406C7D6DFF5DC0F8B3869788B9',
       ledger_index: 78893311,

--- a/src/components/NftMinter/index.jsx
+++ b/src/components/NftMinter/index.jsx
@@ -1,5 +1,4 @@
 import { Button } from '@mui/material';
-import { extractAffectedNFT } from '@xrplkit/txmeta';
 import { Buffer } from 'buffer';
 import { NFTStorage } from 'nft.storage';
 import { useEffect, useState } from 'react';
@@ -76,9 +75,9 @@ export const NftMinter = () => {
       transaction: txid,
     });
     // トランザクション情報からNFTの情報を取得します。
-    const nftoken = extractAffectedNFT(txResponse);
+    const nftokenId = txResponse.meta.nftoken_id;
     alert('NFTトークンが発行されました!');
-    window.open(`https://test.bithomp.com/nft/${nftoken.NFTokenID}`, '_blank');
+    window.open(`https://test.bithomp.com/nft/${nftokenId}`, '_blank');
   };
 
   return (


### PR DESCRIPTION
- https://github.com/unchain-tech/UNCHAIN-projects/pull/429

## 変更内容

- `@xrplkit/txmeta`を用いたNFTokenIDの取得処理を削除
- トランザクションの結果を保持するtxResponse変数から直接`nftoken_id`を取得するよう変更

## 背景

XRPLのノードがv1.11.0により`NFTokenMint`トランザクションのTxResponseに`nftoken_id`フィールドが含まれるようになったため。

## 備考

[v1.11.0](https://xrpl.org/blog/2023/rippled-1.11.0.html)