### PR TITLE
chore: comment out mock

### DIFF
--- a/src/components/NftMinter/index.test.jsx
+++ b/src/components/NftMinter/index.test.jsx
@@ -5,19 +5,20 @@ import { Xumm } from 'xumm';
 
 import { NftMinter } from '.';
 
-jest.mock('nft.storage', () => {
-  const { MockedNFTStorage } = require('../../__test__/__mock__/NFTStorage');
-  return { NFTStorage: MockedNFTStorage };
-});
+// Section2 Lesson2 「📝 NFTのMint処理を実装しよう」が完了した後にコメントアウトを外してください。
+// jest.mock('nft.storage', () => {
+//   const { MockedNFTStorage } = require('../../__test__/__mock__/NFTStorage');
+//   return { NFTStorage: MockedNFTStorage };
+// });
+
+// jest.mock('xrpl-client', () => {
+//   const { XrplClient } = require('../../__test__/__mock__/XrplClient');
+//   return { XrplClient };
+// });
 
 jest.mock('xumm', () => {
   const { MockedXumm } = require('../../__test__/__mock__/Xumm');
   return { Xumm: MockedXumm };
-});
-
-jest.mock('xrpl-client', () => {
-  const { XrplClient } = require('../../__test__/__mock__/XrplClient');
-  return { XrplClient };
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## 変更内容
Section2 Lesson2 の後半でインストール・実装するモジュールのモックを、あらかじめコメントアウトするようにしました。

## 背景
該当モジュールをインストールする前にテストを実行するステップあるのですが、`Cannot fine module`が発生してテストが止まってしまっていたためです。

### 修正前：

![Screenshot 2023-11-15 at 18 51 51](https://github.com/unchain-tech/XRPL-NFT-Maker/assets/60546319/27684cf9-366a-42a3-acfb-3ac1677cc373)

### 修正後：

![Screenshot 2023-11-15 at 22 07 44](https://github.com/unchain-tech/XRPL-NFT-Maker/assets/60546319/52843427-6969-4951-ae0f-9abf4b8a8912)

## その他
学習コンテンツの修正PR： https://github.com/unchain-tech/UNCHAIN-projects/pull/467
